### PR TITLE
update link to point to 'develop' branch

### DIFF
--- a/docs/aspireupdate/index.md
+++ b/docs/aspireupdate/index.md
@@ -13,7 +13,7 @@ permalink: /aspireupdate/
 
 Download and install AspireUpdate:
 
-[In Development](https://github.com/aspirepress/AspireUpdate/tree/main)
+[In Development](https://github.com/aspirepress/AspireUpdate/tree/develop)
 
 
 WP Playground:


### PR DESCRIPTION
# Pull Request

## What changed?

update to use latest mermaid distribution from jsdelivr
link to the 'develop' branch of AspireUpdate from docs

## Why did it change?

the current test state is to test from 'develop' branch until we have a stable 'main' branch

## Did you fix any specific issues?
no

## CERTIFICATION

By opening this pull request, I do agree to abide by
the [CODE OF CONDUCT](https://github.com/aspirepress/.github/CODE_OF_CONDUCT.md) and be bound by the terms
of the [Contribution Guidelines](https://github.com/aspirepress/.github/CONTRIBUTING.md) in effect on the date and time
of my contribution as proven by the
revision information in GitHub. I also agree that any previous contributions shall be deemed subject to the terms of the
version in effect on the date and time of this pull request, or any future revisions for pull requests I may submit.
Further, I certify that this work is my own, is original, does not violate the intellectual property of any other person
or entity, and I am not violating any license agreements or contracts I have with any person or entity. Finally, I agree
that this code may be licensed under any license deemed appropraite by AspirePress, including but not
limited to open source, closed source, proprietary or custom licenses, and that such license terms neither violate my
rights or my copyright to this code.