### PR TITLE
Adding a change log

### DIFF
--- a/_data/menu_v2.yml
+++ b/_data/menu_v2.yml
@@ -8,13 +8,16 @@ AspirePress:
 AspireCloud:
     Introduction: '/aspirecloud/'
     Work: '/aspirecloud/work/'    
-    
+    Changelog: '/aspirecloud/changelog/'
+
 
 AspireSync:
     Introduction: '/aspiresync/'
     Work: '/aspiresync/work/'    
+    Changelog: '/aspiresync/changelog/'
     
 
 AspireUpdate:
     Introduction: '/aspireupdate/'
     Work: '/aspireupdate/work/' 
+    Changelog: '/aspireupdate/changelog/'

--- a/docs/aspirecloud/changelog.md
+++ b/docs/aspirecloud/changelog.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - e
 
+### New contrubutors  
+
+- @x on #007
+
+  
 ## [0.0.0] - YYYY-MM-DD  (Link to relase in GitHub)
 
 ### Added
@@ -54,5 +59,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security 
 
 - e
+
+### New contrubutors  
+
+- @x on #007
 
 

--- a/docs/aspirecloud/changelog.md
+++ b/docs/aspirecloud/changelog.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+<!-- When we have a release we can uncomment the this and start using the below template
+
 ## [Unreleased]
 
 ### Added
@@ -63,5 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New contrubutors  
 
 - @x on #007
+
+-->
 
 

--- a/docs/aspirecloud/changelog.md
+++ b/docs/aspirecloud/changelog.md
@@ -1,0 +1,58 @@
+---
+layout: default
+title: Welcome to AspireCloud
+permalink: /aspirecloud/changelog/
+---
+
+# AspireCloud Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- a (#001 link to issue if we have one)
+
+### Changed
+
+- b
+
+### Removed
+
+- c
+
+### Fixed
+
+- d
+
+### Security 
+
+- e
+
+## [0.0.0] - YYYY-MM-DD  (Link to relase in GitHub)
+
+### Added
+
+- a (#001 link to issue if we have one)
+
+### Changed
+
+- b
+
+### Removed
+
+- c
+
+### Fixed
+
+- d
+
+### Security 
+
+- e
+
+

--- a/docs/aspiresync/changelog.md
+++ b/docs/aspiresync/changelog.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- When we have a release we can uncomment the this and start using the below template
+
 ## [Unreleased]
 
 ### Added
@@ -64,5 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - @x on #007
 
+
+-->
 
 

--- a/docs/aspiresync/changelog.md
+++ b/docs/aspiresync/changelog.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - e
 
+### New contrubutors  
+
+- @x on #007
+
+
 ## [0.0.0] - YYYY-MM-DD  (Link to relase in GitHub)
 
 ### Added
@@ -54,5 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security 
 
 - e
+
+### New contrubutors  
+
+- @x on #007
+
 
 

--- a/docs/aspiresync/changelog.md
+++ b/docs/aspiresync/changelog.md
@@ -1,0 +1,58 @@
+---
+layout: default
+title: Welcome to AspireSync
+permalink: /aspirecloud/changelog/
+---
+
+# AspireSync Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- a (#001 link to issue if we have one)
+
+### Changed
+
+- b
+
+### Removed
+
+- c
+
+### Fixed
+
+- d
+
+### Security 
+
+- e
+
+## [0.0.0] - YYYY-MM-DD  (Link to relase in GitHub)
+
+### Added
+
+- a (#001 link to issue if we have one)
+
+### Changed
+
+- b
+
+### Removed
+
+- c
+
+### Fixed
+
+- d
+
+### Security 
+
+- e
+
+

--- a/docs/aspireupdate/changelog.md
+++ b/docs/aspireupdate/changelog.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- When we have a release we can uncomment the this and start using the below template
+
 ## [Unreleased]
 
 ### Added
@@ -64,4 +66,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - @x on #007
 
-
+-->

--- a/docs/aspireupdate/changelog.md
+++ b/docs/aspireupdate/changelog.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - e
 
+### New contrubutors  
+
+- @x on #007
+
+
 ## [0.0.0] - YYYY-MM-DD  (Link to relase in GitHub)
 
 ### Added
@@ -54,5 +59,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security 
 
 - e
+
+### New contrubutors  
+
+- @x on #007
 
 

--- a/docs/aspireupdate/changelog.md
+++ b/docs/aspireupdate/changelog.md
@@ -1,0 +1,58 @@
+---
+layout: default
+title: Welcome to AspireUpdate
+permalink: /aspirecloud/changelog/
+---
+
+# AspireUpdate Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- a (#001 link to issue if we have one)
+
+### Changed
+
+- b
+
+### Removed
+
+- c
+
+### Fixed
+
+- d
+
+### Security 
+
+- e
+
+## [0.0.0] - YYYY-MM-DD  (Link to relase in GitHub)
+
+### Added
+
+- a (#001 link to issue if we have one)
+
+### Changed
+
+- b
+
+### Removed
+
+- c
+
+### Fixed
+
+- d
+
+### Security 
+
+- e
+
+


### PR DESCRIPTION
# Pull Request

## What changed?

adds 3 markdown files for changelogs 

## Why did it change?

Starts to resolve  https://github.com/aspirepress/documentation/issues/27 

Still need to add a GitHub Action to populate the Changelogs...


## Did you fix any specific issues?

Consistency to changelogs 
I would check the HTML comment added in the mark down file is hidden from the front end, if not we could use / try the liquid template format.. or just don't add the link to the menu until we add a new version. 

```
{% comment %} 
{% endcomment %}
```


## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

