### PR TITLE
AP config docs change

### DIFF
--- a/docs/aspireupdate/index.md
+++ b/docs/aspireupdate/index.md
@@ -125,5 +125,5 @@ A: In the current version of AspireUpdate, the “Favorites” and “Features�
 
 ### Configuration
 
-By default the plugin is accessing the api.aspirecloud.org endpoint. There should be no other configuration required. You can turn on the debug log and reset the settings. Use the advanced=true query param in the settings screen to turn on advanced configuration settings.
+By default the plugin is accessing the api.aspirecloud.org endpoint. There should be no other configuration required. You can turn on the debug log and reset the settings. 
 


### PR DESCRIPTION
# Pull Request

## What changed?

Removed Use the advanced=true query param in the settings screen to turn on advanced configuration settings. 

Can someone check this is not a bug, and should have been removed. 

## Why did it change?

requested here https://github.com/aspirepress/documentation/issues/36

## Did you fix any specific issues?

fixes #36  

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

