### PR TITLE
Update Gemfile for last mod date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source 'https://rubygems.org'
 group :jekyll_plugins do
   gem 'github-pages'
   gem 'jekyll-sitemap'
+  gem "jekyll-last-modified-at"
 end


### PR DESCRIPTION
# Pull Request

## What changed?

When working on https://github.com/aspirepress/documentation/issues/40 I forgot to add the plugin to the gem file

## Why did it change?

to address https://github.com/aspirepress/documentation/issues/40

## Did you fix any specific issues?

This should make the date show 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

